### PR TITLE
Change libdvbsi repo in CI workflow

### DIFF
--- a/.github/workflows/enigma2.yml
+++ b/.github/workflows/enigma2.yml
@@ -30,8 +30,8 @@ jobs:
         echo installing libdvbsi++
         pushd .
         cd /tmp
-        git clone --depth 1 git://git.opendreambox.org/git/obi/libdvbsi++.git
-        cd libdvbsi++
+        git clone --depth 1 https://github.com/jack2015/libdvbsi.git
+        cd libdvbsi
         autoreconf -i
         ./configure
         make


### PR DESCRIPTION
It looks like git.opendreambox.org is currently unavailable, and this throws an error in workflow.