### PR TITLE
Fix MenuList initialize in FIFOList

### DIFF
--- a/lib/python/Components/FIFOList.py
+++ b/lib/python/Components/FIFOList.py
@@ -3,9 +3,8 @@ from Components.MenuList import MenuList
 
 class FIFOList(MenuList):
 	def __init__(self, list=[], len=10):
-		self.list = list
 		self.len = len
-		MenuList.__init__(self, self.list)
+		MenuList.__init__(self, list)
 
 	def addItem(self, item):
 		self.list.append(item)


### PR DESCRIPTION
This fix AttributeError: 'FIFOList' object has no attribute 'l' after https://github.com/OpenPLi/enigma2/commit/fb23b131cebce07c4ae7c08b5d7ec4801c238754 Thx Amai for report.